### PR TITLE
[FIX] bug no response after clicking "授予" in the rational case

### DIFF
--- a/soulpermission/src/main/java/com/qw/soul/permission/request/PermissionFragmentFactory.java
+++ b/soulpermission/src/main/java/com/qw/soul/permission/request/PermissionFragmentFactory.java
@@ -19,22 +19,24 @@ class PermissionFragmentFactory {
         if (activity instanceof FragmentActivity) {
             FragmentManager supportFragmentManager = ((FragmentActivity) activity).getSupportFragmentManager();
             PermissionSupportFragment permissionSupportFragment = (PermissionSupportFragment) supportFragmentManager.findFragmentByTag(FRAGMENT_TAG);
-            if (null == permissionSupportFragment) {
-                permissionSupportFragment = new PermissionSupportFragment();
-                supportFragmentManager.beginTransaction()
-                        .add(permissionSupportFragment, FRAGMENT_TAG)
-                        .commitNowAllowingStateLoss();
+            android.support.v4.app.FragmentTransaction transaction = supportFragmentManager.beginTransaction();
+            if (permissionSupportFragment != null) { // 如果已存在PermissionFragment的实例，先将它移除，然后再添加新的
+                transaction.remove(permissionSupportFragment);
             }
+            permissionSupportFragment = new PermissionSupportFragment();
+            transaction.add(permissionSupportFragment, FRAGMENT_TAG);
+            transaction.commitAllowingStateLoss();
             action = permissionSupportFragment;
         } else {
             android.app.FragmentManager fragmentManager = activity.getFragmentManager();
             PermissionFragment permissionFragment = (PermissionFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
-            if (null == permissionFragment) {
-                permissionFragment = new PermissionFragment();
-                activity.getFragmentManager().beginTransaction()
-                        .add(permissionFragment, FRAGMENT_TAG)
-                        .commitAllowingStateLoss();
+            android.app.FragmentTransaction transaction = fragmentManager.beginTransaction();
+            if (permissionFragment != null) { // 如果已存在PermissionFragment的实例，先将它移除，然后再添加新的
+                transaction.remove(permissionFragment);
             }
+            permissionFragment = new PermissionFragment();
+            transaction.add(permissionFragment, FRAGMENT_TAG);
+            transaction.commitAllowingStateLoss();
             action = permissionFragment;
         }
         return action;


### PR DESCRIPTION
bug复现步骤：
1、用RequestPermissionWithRationaleListener的实例作为回调，申请授权；
2、拒绝；
3、在确认授权的弹窗中点击“授权”
<img width="332" alt="图片" src="https://user-images.githubusercontent.com/9261703/58011522-02a6c100-7b25-11e9-9907-d0b5eaf367c6.png">

预期结果：
再次出现申请授权弹窗

实际：
app无响应

问题原因：
在PermissionFragmentFactory中，由于已存在PermissionFragment的实例，所以并没有再次进行add fragment的操作。

修复方案：
如果已存在PermissionFragment的实例，先将它移除，然后再添加新的